### PR TITLE
Update ZonesModel.js

### DIFF
--- a/public/js/playlists/compose/multizone/ZonesModel.js
+++ b/public/js/playlists/compose/multizone/ZonesModel.js
@@ -140,10 +140,10 @@ export class ZonesModel
 		if (zones.hasOwnProperty("resolution"))
 		{
 			this.#export_unit = zones.export_unit;
-			this.#Zones       = this.#prepareZones(zones.zones)
-			this.#zoom        = zones.zoom;
 			this.#screen_width = zones.resolution.split("x")[0];
 			this.#screen_height = zones.resolution.split("x")[1];
+			this.#Zones       = this.#prepareZones(zones.zones)
+			this.#zoom        = zones.zoom;
 		}
 		else // the old format
 		{


### PR DESCRIPTION
ZonesModel loads previously saved widths/heights before prepareZones. This should fix #27 . The issue was only happening when Percent was selected, not pixel. 