### PR TITLE
fix: typo in english translation

### DIFF
--- a/translations/en/profile.ini
+++ b/translations/en/profile.ini
@@ -1,5 +1,5 @@
 password = "Password"
-password_reset = "Passwort reset"
+password_reset = "Password reset"
 password_confirm = "Repeat password to confirm"
 password_explanation = "Your password must be at least 8 characters long and include uppercase letters, lowercase letters, and numbers."
 password_changed = "Password successfully changed."


### PR DESCRIPTION
Simple fix for a single typo

fixes garlic-signage/garlic-hub#45