### PR TITLE
fix: prevent browser default contextmenu

### DIFF
--- a/public/js/playlists/compose/multizone/ContextMenu.js
+++ b/public/js/playlists/compose/multizone/ContextMenu.js
@@ -46,6 +46,7 @@ export class ContextMenu
 		this.context_menu.style.left = this.options.e.pageX + "px";
 		this.context_menu.style.top = this.options.e.pageY + "px";
 		this.context_menu.innerHTML = document.getElementById("context-menu").innerHTML;
+		this.context_menu.addEventListener('contextmenu', e => e.preventDefault());
 		document.body.append(this.context_menu);
 	}
 

--- a/public/js/templates/canvas-composer/Views/ContextMenuView.js
+++ b/public/js/templates/canvas-composer/Views/ContextMenuView.js
@@ -42,6 +42,7 @@ export class ContextMenuView
 		this.#composerContextMenu.style.position = "fixed";
 		this.#composerContextMenu.style.zIndex = 1000;
 		this.#composerContextMenu.style.display = "none";
+		this.#composerContextMenu.addEventListener('contextmenu', e => e.preventDefault());
 	};
 
 


### PR DESCRIPTION
Previously right clicking in multizone and template editors would open the browser default context menu on top of the garlic-hub menu. Clicking on zones or objects would cause the mouse up event to be handled but the event wasn't prevented from reaching the default browser behaviour. This commit adds preventDefault() on the garlic-hub context-menu elements and thus the default context-menu is not shown.

fixes garlic-signage/garlic-hub#47