### PR TITLE
fix: undefined font when selecting textbox first time

### DIFF
--- a/public/js/templates/canvas-composer/Services/Properties/TextPropertiesService.js
+++ b/public/js/templates/canvas-composer/Services/Properties/TextPropertiesService.js
@@ -31,7 +31,7 @@ export class TextPropertiesService extends BasePropertyService
 	{
 		const object = this._getActiveObject();
 		const styles = object.getSelectionStyles(object.isEditing ? object.selectionStart : 0, object.isEditing ? object.selectionEnd : 9, false)
-		return styles && styles[0] ? styles[0].fontFamily : object.fontFamily
+		return styles[0] && styles[0].fontFamily ? styles[0].fontFamily : object.fontFamily
 	}
 
 	setTextFontFamily(fontFamily)


### PR DESCRIPTION
logic for selecting either active objects or first characters fontFamily always selects undefined value for default text

fixes garlic-signage/garlic-hub#54