### PR TITLE
fix: incorrect canvas size shown in template editor

### DIFF
--- a/public/js/templates/canvas-composer/Controller/ViewportController.js
+++ b/public/js/templates/canvas-composer/Controller/ViewportController.js
@@ -88,6 +88,8 @@ export class ViewportController
 		);
 
 		this.#viewportService.initializeFromCanvas()
+		this.#viewportView.setResolutionWidth(this.#viewportService.width)
+		this.#viewportView.setResolutionHeight(this.#viewportService.height)
 		this.zoomToViewPort();
 	}
 


### PR DESCRIPTION
If you change canvas size and refresh the page the canvas is changed but canvas size inputs don't show the changed resolution.

fixes garlic-signage/garlic-hub#56