### PR TITLE
typo in zone background color

### DIFF
--- a/templates/player/index/garlic.smil.mustache
+++ b/templates/player/index/garlic.smil.mustache
@@ -23,7 +23,7 @@
 		<layout>
             <root-layout id="display:0" width="{{{ROOT_LAYOUT_WIDTH}}}" height="{{{ROOT_LAYOUT_HEIGHT}}}" />
 			{{#regions}}
-			<region regionName="screen{{{SCREEN_ID}}}" top="{{{REGION_TOP}}}" left="{{{REGION_LEFT}}}" width="{{{REGION_WIDTH}}}" height="{{{REGION_HEIGHT}}}" z-index="{{{REGION_Z_INDEX}}}" background-color="{{{REGION_BGCOLOR}}}" mediaAlign="center"/>
+			<region regionName="screen{{{SCREEN_ID}}}" top="{{{REGION_TOP}}}" left="{{{REGION_LEFT}}}" width="{{{REGION_WIDTH}}}" height="{{{REGION_HEIGHT}}}" z-index="{{{REGION_Z_INDEX}}}" backgroundColor="{{{REGION_BGCOLOR}}}" mediaAlign="center"/>
 			{{/regions}}
 		</layout>
 		{{/layout}}


### PR DESCRIPTION
typo caused zone backgroundColor feature to be broken

fixes garlic-signage/garlic-hub#60