### PR TITLE
fix: mediapool items overflowing container

### DIFF
--- a/public/css/mediapool/selector.css
+++ b/public/css/mediapool/selector.css
@@ -19,6 +19,7 @@
         padding: 1em;
         box-sizing: border-box;
         overflow-y: auto;
+        max-height: 73.8vh;
     }
             .media-item
             {


### PR DESCRIPTION
When uploading many items to mediapool they overflow the playlist media selector container

fixes garlic-signage/garlic-hub#71